### PR TITLE
fix: GitHub Issues #2, #3, #4 対応

### DIFF
--- a/scripts/modules/api_fetcher.py
+++ b/scripts/modules/api_fetcher.py
@@ -49,9 +49,9 @@ class SimpleOpenAPIFetcher:
             if date == today:
                 url = f"{self.programs_base_url}/today.json"
             else:
-                # 日付形式をYYYYMMDD.jsonに変換
-                date_formatted = date.replace('-', '')
-                url = f"{self.programs_base_url}/2025/{date_formatted}.json"
+                # 日付から年を動的に取得してURLを生成
+                date_obj = datetime.strptime(date, '%Y-%m-%d')
+                url = f"{self.programs_base_url}/{date_obj.year}/{date_obj.strftime('%Y%m%d')}.json"
             
             response = requests.get(url, timeout=10)
             if response.status_code == 200:
@@ -111,9 +111,9 @@ class SimpleOpenAPIFetcher:
             if date == today:
                 url = f"{self.results_base_url}/today.json"
             else:
-                # 日付形式をYYYYMMDD.jsonに変換
-                date_formatted = date.replace('-', '')
-                url = f"{self.results_base_url}/2025/{date_formatted}.json"
+                # 日付から年を動的に取得してURLを生成
+                date_obj = datetime.strptime(date, '%Y-%m-%d')
+                url = f"{self.results_base_url}/{date_obj.year}/{date_obj.strftime('%Y%m%d')}.json"
             
             response = requests.get(url, timeout=10)
             if response.status_code == 200:

--- a/scripts/modules/core/real_api_tracker.py
+++ b/scripts/modules/core/real_api_tracker.py
@@ -331,7 +331,10 @@ class RealAPITracker:
             # 予想結果を生成
             predicted_win = boat_scores[0]['boat_number']
             predicted_place = [boat['boat_number'] for boat in boat_scores[:3]]
-            confidence = min(0.95, max(0.05, boat_scores[0]['score'] / 100.0))
+            # スコアを100で割るのではなく、正規化して0.05-0.95の範囲に収める
+            max_score = max(boat['score'] for boat in boat_scores) if boat_scores else 100.0
+            normalized_score = boat_scores[0]['score'] / max_score if max_score > 0 else 0.5
+            confidence = min(0.95, max(0.05, normalized_score * 0.9 + 0.05))
             
             logger.info(f"予想完了: 単勝={predicted_win}号艇, 複勝={predicted_place}, 信頼度={confidence:.2%}")
             
@@ -343,7 +346,7 @@ class RealAPITracker:
                     'boat_number': boat_score['boat_number'],
                     'name': boat_data.get('racer_name', f"{boat_score['boat_number']}号艇"),
                     'racer_name': boat_data.get('racer_name', f"{boat_score['boat_number']}号艇"),
-                    'prediction_score': boat_score['score'] / 100.0,  # 0-1の範囲に正規化
+                    'prediction_score': min(1.0, boat_score['score'] / max_score),  # 0-1の範囲に正規化
                     'win_rate': boat_data.get('racer_national_top_1_percent', 0),
                     'local_win_rate': boat_data.get('racer_local_top_1_percent', 0),
                     'place_rate': boat_data.get('racer_national_top_3_percent', 0),


### PR DESCRIPTION
## 修正対象Issues
- Closes #2: get_results_for_date関数の年ハードコード問題
- Closes #3: get_programs_for_date関数の年ハードコード問題  
- Closes #4: 的中率レポートの信頼度が110%になる問題

## 修正内容

### Issue #4: 信頼度110%問題
**問題**: スコア計算で各要素（勝率等）をパーセンテージで合計していたため、total_scoreが100を超えて信頼度が110%になることがあった

**修正内容**:
- スコアを最高得点者で正規化し、0.05-0.95の範囲に制限
- 信頼度計算式を `normalized_score * 0.9 + 0.05` に変更
- テンプレート用スコアも同様に正規化

### Issue #3 & #2: 年ハードコード問題
**問題**: APIのURL生成時に年が2025に固定されており、他年度のデータ取得ができない

**修正内容**:
- `datetime.strptime(date, '%Y-%m-%d')` で日付を解析
- `date_obj.year` で動的に年を取得
- URL生成を `/{year}/{YYYYMMDD}.json` 形式に修正

## テスト計画
- [x] 信頼度が100%以下になることを確認
- [x] 2024年以前・2026年以降の日付でAPIが正常動作することを確認
- [x] 既存の今日のデータ取得機能が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)